### PR TITLE
Pass password using stdin

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -20,10 +20,23 @@ func newCommand(args ...Param) (cmd *exec.Cmd, stdout, stderr *bytes.Buffer) {
 	return
 }
 
+func ExecCommandWithStdin(stdin string, args ...Param) (stdout *bytes.Buffer, err error) {
+
+	cmd, stdout, stderr := newCommand(args...)
+	cmd.Stdin = strings.NewReader(stdin)
+
+	if err = cmd.Run(); err != nil {
+		return stdout, parseError(stderr.String())
+	}
+
+	return stdout, nil
+}
+
 // ExecCommand executes a simple command and returns a buffer with the console output and eventually an
 // error, if an error was encountered.
 func ExecCommand(args ...Param) (stdout *bytes.Buffer, err error) {
 	cmd, stdout, stderr := newCommand(args...)
+
 	if err = cmd.Run(); err != nil {
 		return stdout, parseError(stderr.String())
 	}

--- a/cmd.go
+++ b/cmd.go
@@ -20,6 +20,8 @@ func newCommand(args ...Param) (cmd *exec.Cmd, stdout, stderr *bytes.Buffer) {
 	return
 }
 
+// ExecCommandWithStdin adds string to the stdin in of a command, executes the command and returns a buffer with the console output and eventually an
+// error, if an error was encountered.
 func ExecCommandWithStdin(stdin string, args ...Param) (stdout *bytes.Buffer, err error) {
 
 	cmd, stdout, stderr := newCommand(args...)

--- a/cmd.go
+++ b/cmd.go
@@ -20,7 +20,7 @@ func newCommand(args ...Param) (cmd *exec.Cmd, stdout, stderr *bytes.Buffer) {
 	return
 }
 
-// ExecCommandWithStdin adds string to the stdin in of a command, executes the command and returns a buffer with the console output and eventually an
+// ExecCommandWithStdin adds a string to the stdin of a command, executes the command and returns a buffer with the console output and eventually an
 // error, if an error was encountered.
 func ExecCommandWithStdin(stdin string, args ...Param) (stdout *bytes.Buffer, err error) {
 

--- a/dismount_test.go
+++ b/dismount_test.go
@@ -1,8 +1,9 @@
 package vera
 
 import (
-	"github.com/stretchr/testify/suite"
 	"testing"
+
+	"github.com/stretchr/testify/suite"
 )
 
 type DismountTestSuite struct {
@@ -50,7 +51,7 @@ func (suite *DismountTestSuite) TestDismountSlotReturnsErrParameterIncorrectIfIn
 }
 
 func (suite *DismountTestSuite) TestDismountSlotReturnsNoErrMountedVolumeDismounted() {
-	_, err := Mount("./testdata/basic.vc", 1, Param{Name: "password", Value: "123456789"})
+	_, err := Mount("./testdata/basic.vc", 1, "123456789")
 	suite.NoError(err)
 
 	err = DismountSlot(1)
@@ -58,7 +59,7 @@ func (suite *DismountTestSuite) TestDismountSlotReturnsNoErrMountedVolumeDismoun
 }
 
 func (suite *DismountTestSuite) TestDismountVolumeReturnsNoErrMountedVolumeDismounted() {
-	_, err := Mount("./testdata/basic.vc", 1, Param{Name: "password", Value: "123456789"})
+	_, err := Mount("./testdata/basic.vc", 1, "123456789")
 	suite.NoError(err)
 
 	err = DismountVolume("./testdata/basic.vc")
@@ -66,7 +67,7 @@ func (suite *DismountTestSuite) TestDismountVolumeReturnsNoErrMountedVolumeDismo
 }
 
 func (suite *DismountTestSuite) TestDismountVolumeReturnsErrMountedVolumeDismountedOnlyName() {
-	_, err := Mount("./testdata/basic.vc", 1, Param{Name: "password", Value: "123456789"})
+	_, err := Mount("./testdata/basic.vc", 1, "123456789")
 	suite.NoError(err)
 
 	err = DismountVolume("basic.vc")
@@ -75,7 +76,7 @@ func (suite *DismountTestSuite) TestDismountVolumeReturnsErrMountedVolumeDismoun
 }
 
 func (suite *DismountTestSuite) TestDismountAllReturnsNoErrMountedVolumeDismounted() {
-	_, err := Mount("./testdata/basic.vc", 1, Param{Name: "password", Value: "123456789"})
+	_, err := Mount("./testdata/basic.vc", 1, "123456789")
 	suite.NoError(err)
 
 	err = DismountAll()

--- a/list_test.go
+++ b/list_test.go
@@ -1,9 +1,10 @@
 package vera
 
 import (
-	"github.com/stretchr/testify/suite"
 	"path"
 	"testing"
+
+	"github.com/stretchr/testify/suite"
 )
 
 type ListTestSuite struct {
@@ -76,7 +77,7 @@ func (suite ListTestSuite) TestPropertiesVolumeErrNoSuchVolumeMounted() {
 // check if the PropertiesSlot func returns a MountProperties struct that matches the mounted volume
 func (suite ListTestSuite) TestPropertiesSlotReturnsCorrectMountProperties() {
 	const volume = "./testdata/basic.vc"
-	mountProps, err := Mount(volume, 1, Param{Name: "p", Value: "123456789"})
+	mountProps, err := Mount(volume, 1, "123456789")
 	suite.NoError(err)
 
 	props, err := PropertiesSlot(1)
@@ -89,7 +90,7 @@ func (suite ListTestSuite) TestPropertiesSlotReturnsCorrectMountProperties() {
 // check if the PropertiesVolume func returns a MountProperties struct that matches the mounted volume
 func (suite ListTestSuite) TestPropertiesVolumeReturnsCorrectMountProperties() {
 	const volume = "./testdata/basic.vc"
-	mountProps, err := Mount(volume, 1, Param{Name: "p", Value: "123456789"})
+	mountProps, err := Mount(volume, 1, "123456789")
 	suite.NoError(err)
 
 	props, err := PropertiesVolume(volume)
@@ -102,7 +103,7 @@ func (suite ListTestSuite) TestPropertiesVolumeReturnsCorrectMountProperties() {
 // make sure both PropertiesSlot and PropertiesVolume are returning the same data
 func (suite ListTestSuite) TestPropertiesVolumeAndPropertiesSlotReturnTheSameData() {
 	const volume = "./testdata/basic.vc"
-	_, err := Mount(volume, 1, Param{Name: "p", Value: "123456789"})
+	_, err := Mount(volume, 1, "123456789")
 	suite.NoError(err)
 
 	propsSlot, _ := PropertiesSlot(1)

--- a/mount.go
+++ b/mount.go
@@ -4,17 +4,17 @@ import (
 	"strconv"
 )
 
-// Mount mounts the volume in the given slot. Depending on the volume, the appropriate parameters must be set, but at
-// least the password
-func Mount(volume string, slot uint8, opts ...Param) (MountProperties, error) {
+// Mount mounts the volume in the given slot. Depending on the volume, the appropriate parameters must be set.
+// password is passed through stdin
+func Mount(volume string, slot uint8, password string, opts ...Param) (MountProperties, error) {
 	// check if the slot number is supported
 	if err := slotValid(slot); err != nil {
 		return MountProperties{}, err
 	}
 
 	// append path and mount as Param
-	opts = append(opts, Param{Value: volume}, Param{Name: "slot", Value: strconv.Itoa(int(slot))})
-	_, err := ExecCommand(opts...)
+	opts = append(opts, Param{Value: volume}, Param{Name: "slot", Value: strconv.Itoa(int(slot))}, Param{Name: "stdin", IsFlag: true})
+	_, err := ExecCommandWithStdin(password, opts...)
 	if err != nil {
 		return MountProperties{}, err
 	}

--- a/mount_test.go
+++ b/mount_test.go
@@ -1,8 +1,9 @@
 package vera
 
 import (
-	"github.com/stretchr/testify/suite"
 	"testing"
+
+	"github.com/stretchr/testify/suite"
 )
 
 type MountTestSuite struct {
@@ -25,18 +26,18 @@ func (suite MountTestSuite) TestSlotOutOfBoundsErrParameterIncorrect() {
 	emptyProps := MountProperties{}
 
 	// there is no slot 0
-	props, err := Mount("./testdata/basic.vc", 0, Param{Name: "password", Value: "123456789"})
+	props, err := Mount("./testdata/basic.vc", 0, "123456789")
 	suite.Equal(emptyProps, props)
 	suite.ErrorIs(err, ErrParameterIncorrect)
 
 	// VeraCrypt only supports 64 slots
-	_, err = Mount("./testdata/basic.vc", 65, Param{Name: "password", Value: "123456789"})
+	_, err = Mount("./testdata/basic.vc", 65, "123456789")
 	suite.Equal(emptyProps, props)
 	suite.ErrorIs(err, ErrParameterIncorrect)
 }
 
 func (suite *MountTestSuite) TestBasicVolumeMount() {
-	props, err := Mount("./testdata/basic.vc", 2, Param{Name: "password", Value: "123456789"})
+	props, err := Mount("./testdata/basic.vc", 2, "123456789")
 
 	suite.NoError(err)
 	suite.NotEqual(MountProperties{}, props)
@@ -44,7 +45,7 @@ func (suite *MountTestSuite) TestBasicVolumeMount() {
 }
 
 func (suite *MountTestSuite) TestBasicVolumeMountIncorrectPassword() {
-	props, err := Mount("./testdata/basic.vc", 2, Param{Name: "password", Value: "1234567890"}) // password is 123456789
+	props, err := Mount("./testdata/basic.vc", 2, "1234567890") // password is 123456789
 
 	suite.Error(err)
 	suite.ErrorIs(err, ErrOperationFailed)
@@ -52,7 +53,7 @@ func (suite *MountTestSuite) TestBasicVolumeMountIncorrectPassword() {
 }
 
 func (suite *MountTestSuite) TestBasicVolumeMountComplexPassword() {
-	props, err := Mount("./testdata/basic-complex-pw.vc", 2, Param{Name: "password", Value: `s8&"f^T$r'`})
+	props, err := Mount("./testdata/basic-complex-pw.vc", 2, `s8&"f^T$r'`)
 
 	suite.NoError(err)
 	suite.NotEqual(MountProperties{}, props)


### PR DESCRIPTION
Hi there, 

This PR implements passing a password through stdin, which increases security. In the current implementation passwords are passed as arguments, and are thus visible in /proc/PID/cmdline. For mounting, the problem might be small, as the cmdline is exposed only shortly (even then, its exposed in a world readable file...). For creating a volume, this would be a big issue, as the cmdline is exposed for the entire duration of creation. In that sense, the PR is the first step to securely creating volumes as well. See the example below for more info.

Let me know if you want me to merge to a different branch instead of develop!


## Current implementation

```go
//main.go

package main

import (
	"github.com/mark-hartmann/vera"
)

func main() {
	DismountAll()
	password := Param{Name: "password", Value: "1234"}
	_, err := Mount("/data/veracrypt/test.vc", 2, password)
	if err != nil {
		fmt.Println(err.Error())
		os.Exit(1)
	}

}
```
I print the info in /proc/PID/cmdline, a world-readable file (!). In the below example I implemented the print functionality in ExecCommand, but I could also have used external shell scripts or tools.

```go
//cmd.go

func ExecCommand(args ...Param) (stdout *bytes.Buffer, err error) {
	cmd, stdout, stderr := newCommand(args...)
	err = cmd.Start()
	if err != nil {
		return stdout, err
	}

	o, err := getCmdline(cmd.Process.Pid)
	if err != nil {
		return stdout, err
	}

	fmt.Printf("I am PID %d and I am the following command:\n %s \n", cmd.Process.Pid, o)
	err = cmd.Wait()
	if err != nil {
		return stdout, parseError(stderr.String())
	}
	return stdout, nil
}

func getCmdline(pid int) (string, error) {
	dat, err := os.ReadFile(fmt.Sprintf("/proc/%s/cmdline", strconv.Itoa(pid)))

	if err != nil {
		return "", err
	}

	return string(dat), nil
}

```

### Console output:
Console output to show the password is clearly visible.

> I am PID 238119 and I am the following command:
 veracrypt -t --non-interactive --dismount 
I am PID 238139 and I am the following command:
 veracrypt -t --non-interactive --password=1234 --slot=2 /data/veracrypt/test.vc 

## New implementation
Piping the password to stdin

Again, we add some debugging to ExecCommand()
```go
//cmd.go

func ExecCommand(args ...Param) (stdout *bytes.Buffer, err error) {
	cmd, stdout, stderr := newCommand(args...)
	err = cmd.Start()
	if err != nil {
		return stdout, err
	}

	o, err := getCmdline(cmd.Process.Pid)
	if err != nil {
		return stdout, err
	}

	fmt.Printf("I am PID %d and I am the following command:\n %s \n", cmd.Process.Pid, o)
	err = cmd.Wait()
	if err != nil {
		return stdout, parseError(stderr.String())
	}
	return stdout, nil
}

func getCmdline(pid int) (string, error) {
	dat, err := os.ReadFile(fmt.Sprintf("/proc/%s/cmdline", strconv.Itoa(pid)))

	if err != nil {
		return "", err
	}

	return string(dat), nil
}

```

1. Add a password parameter to Mount(), as Mount() needs a password anyway, so the additional benefit is that we enforce this now.
2. Pass the password string to ExecCommandWithStdin (I am open to another suggestion on how to pass to stdin, but I thought this was the most elegant and it resembles how Veracrypt would do it on the CLI as well)

```go
//mount.go

// Mount mounts the volume in the given slot. Depending on the volume, the appropriate parameters must be set.
// password is passed through stdin
func Mount(volume string, slot uint8, password string, opts ...Param) (MountProperties, error) {
	// check if the slot number is supported
	if err := slotValid(slot); err != nil {
		return MountProperties{}, err
	}
	
	// append path and mount as Param
	opts = append(opts, Param{Value: volume}, Param{Name: "slot", Value: strconv.Itoa(int(slot))}, Param{Name: "stdin", IsFlag: true})
	_, err := ExecCommandWithStdin(password, opts...)
	if err != nil {
		return MountProperties{}, err
	}

	return PropertiesSlot(slot)
}

//cmd.go
func ExecCommandWithStdin(stdin string, args ...Param) (stdout *bytes.Buffer, err error) {
	cmd, stdout, stderr := newCommand(args...)
	cmd.Stdin = strings.NewReader(stdin)

	err = cmd.Start()
	if err != nil {
		return stdout, err
	}

	o, err := getCmdline(cmd.Process.Pid)
	if err != nil {
		return stdout, err
	}

	fmt.Printf("I am PID %d and I am the following command:\n %s \n", cmd.Process.Pid, o)
	err = cmd.Wait()
	if err != nil {
		return stdout, parseError(stderr.String())
	}
	return stdout, nil
}

```
### Console output

> I am PID 246836 and I am the following command:
 veracrypt -t --non-interactive --dismount 
I am PID 246856 and I am the following command:
 veracrypt -t --non-interactive --slot=2 --stdin /data/veracrypt/test.vc 
I am PID 246913 and I am the following command:
 veracrypt -t --non-interactive --list --slot=2 
2: /data/veracrypt/test.vc /dev/mapper/veracrypt2 /media/veracrypt2
 